### PR TITLE
Implement an Adapter pattern for API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ Example of an Address network. Note that by default Smart Contracts and Initial 
 
 ![address network example](images/network-example.png)
 
-### Blockshout API
-
-[This API](https://blockscout.com/eth/mainnet/graphiql) is free to use and it already gives us transactions and addresses already organized with a lot of information that we need to build our own network.
-
-The downside of using it is rate limits from Cloudflare, and a low complexity GraphQL query, that only enables us to query 22 transactions at a time (with the current information we are requesting).
-
 ### Neo4J Database
 
 To store information we're using [Neo4J](https://neo4j.com/). It's a graph data platform, and that's exactly the structure we want to represent a network of Ethereum Addresses.
@@ -84,10 +78,31 @@ It's also possible to clear the database to delete all nodes and relationships, 
 Neo4j.Client.clear_database
 ```
 
+## API Adapters
+
+### Existing
+ - [Blockscout](https://blockscout.com/eth/mainnet/graphiql): It's free to use and it already gives us transactions and addresses already organized with a lot of information that we need to build our own network. 
+   The downside of using it is rate limits from Cloudflare, and a low complexity GraphQL query, that only enables us to query 22 transactions at a time (with the current information we are requesting).
+
+ 
+### How to implement new ones
+
+Just create a new file under `lib/adapters/api` and implement the respective behaviour.
+
+```
+defmodule Adapters.Api.NewApi do
+  @moduledoc false
+
+  @behaviour Behaviours.Api
+
+  # implementation here
+end
+```
+
 ## Future Development Ideas
 
 - [ ] Add Tests using [Mox](https://hexdocs.pm/mox/Mox.html) to interact with the Blockscout API and Neo4j.
-- [ ] Create an Adapter for the `AddressExplorer` to work with different APIs and/or an Ethereum Node.
+- [X] Create an Adapter for the `AddressExplorer` to work with different APIs and/or an Ethereum Node.
 - [ ] Create an Adapter for `Neo4J.Client`. This way the project can become agnostic on the underlying database provided that the new adapter specifies the Graph structure to be used. With it, we could explore SmartContracts in particular, and just use the project as tooling.
 - [ ] Request more transactions per wallet, using the GraphQL cursors provided by Blockscout API.
 - [ ] Create a scheduler to pick from the `remaining` pool of addresses and set a concurrency number. [Poolboy](https://elixirschool.com/en/lessons/misc/poolboy) for reference.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Neo4j.Client.clear_database
 ## Future Development Ideas
 
 - [ ] Add Tests using [Mox](https://hexdocs.pm/mox/Mox.html) to interact with the Blockscout API and Neo4j.
-- [ ] Create an Adapter for the `AddressExplorer` to work with different APIs or even an Ethereum Node.
+- [ ] Create an Adapter for the `AddressExplorer` to work with different APIs and/or an Ethereum Node.
+- [ ] Create an Adapter for `Neo4J.Client`. This way the project can become agnostic on the underlying database provided that the new adapter specifies the Graph structure to be used. With it, we could explore SmartContracts in particular, and just use the project as tooling.
 - [ ] Request more transactions per wallet, using the GraphQL cursors provided by Blockscout API.
 - [ ] Create a scheduler to pick from the `remaining` pool of addresses and set a concurrency number. [Poolboy](https://elixirschool.com/en/lessons/misc/poolboy) for reference.
 - [ ] Differentiate `Pending`, `ERROR`, and `OK` transactions. Maybe different relationships. (For now, a solution is to use "conditional styling" for relationships in `Neo4J Bloom`.)

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,5 +7,8 @@ config :bolt_sips, Bolt,
   pool_size: 200
 
 config :ethcule_poirot,
+  default_api_adapter: Adapters.Api.Blockscout
+
+config :ethcule_poirot, Adapters.Api.Blockscout,
   api_url: System.get_env("API_URL"),
   api_timeout: 120_000

--- a/lib/adapters/api/blockscout.ex
+++ b/lib/adapters/api/blockscout.ex
@@ -41,7 +41,7 @@ defmodule Adapters.Api.Blockscout do
         query($eth_address: AddressHash!) {
           address(hash: $eth_address) {
             contractCode
-            transactions(first: 22) {
+            transactions(last: 23, count: 23) {
               edges {
                 node {
                   hash
@@ -50,9 +50,6 @@ defmodule Adapters.Api.Blockscout do
                   value
                   status
                 }
-              }
-              pageInfo {
-                hasNextPage
               }
             }
           }

--- a/lib/adapters/api/blockscout.ex
+++ b/lib/adapters/api/blockscout.ex
@@ -1,0 +1,55 @@
+defmodule Adapters.Api.Blockscout do
+  @behaviour Behaviours.Api
+
+  def initial_setup() do
+    Neuron.Config.set(url: Application.fetch_env!(:ethcule_poirot, :api_url))
+
+    Neuron.Config.set(
+      connection_opts: [
+        recv_timeout: Application.fetch_env!(:ethcule_poirot, :api_timeout)
+      ]
+    )
+
+    :ok
+  end
+
+  def address_information(eth_address) do
+    Neuron.query(
+      """
+        query($eth_address: AddressHash!) {
+          address(hash: $eth_address) {
+            contractCode
+          }
+        }
+      """,
+      %{eth_address: eth_address}
+    )
+  end
+
+  def transactions_for_address(eth_address) do
+    Neuron.query(
+      """
+        query($eth_address: AddressHash!) {
+          address(hash: $eth_address) {
+            contractCode
+            transactions(first: 22) {
+              edges {
+                node {
+                  hash
+                  toAddressHash
+                  fromAddressHash
+                  value
+                  status
+                }
+              }
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      """,
+      %{eth_address: eth_address}
+    )
+  end
+end

--- a/lib/adapters/api/blockscout.ex
+++ b/lib/adapters/api/blockscout.ex
@@ -1,12 +1,16 @@
 defmodule Adapters.Api.Blockscout do
+  require Logger
+
   @behaviour Behaviours.Api
 
+  @module_config Application.compile_env(:ethcule_poirot, __MODULE__)
+
   def initial_setup() do
-    Neuron.Config.set(url: Application.fetch_env!(:ethcule_poirot, :api_url))
+    Neuron.Config.set(url: Keyword.get(@module_config, :api_url))
 
     Neuron.Config.set(
       connection_opts: [
-        recv_timeout: Application.fetch_env!(:ethcule_poirot, :api_timeout)
+        recv_timeout: Keyword.get(@module_config, :api_timeout)
       ]
     )
 
@@ -24,6 +28,7 @@ defmodule Adapters.Api.Blockscout do
       """,
       %{eth_address: eth_address}
     )
+    |> final_node_type(eth_address)
   end
 
   def transactions_for_address(eth_address) do
@@ -51,5 +56,56 @@ defmodule Adapters.Api.Blockscout do
       """,
       %{eth_address: eth_address}
     )
+    |> parse_transactions(eth_address)
+  end
+
+  def wei_to_eth(value \\ 0) do
+    value
+    |> Decimal.div(10 ** 18)
+    |> Decimal.to_string(:normal)
+  end
+
+  defp final_node_type({:ok, %Neuron.Response{body: body}}, _eth_address) do
+    contract_code = body["data"]["address"]["contractCode"]
+    %Address{contract: contract_code}
+  end
+
+  defp final_node_type(_request_result, eth_address) do
+    Logger.warn("Failed to obtain address type for #{eth_address}")
+
+    %Address{contract: false}
+  end
+
+  defp parse_transactions({:ok, %Neuron.Response{body: body}}, eth_address) do
+    transactions = body["data"]["address"]["transactions"]["edges"] || []
+    contract_code = body["data"]["address"]["contractCode"]
+
+    transactions_struct =
+      Enum.map(
+        transactions,
+        &%Transaction{
+          hash: &1["node"]["hash"],
+          to_address: &1["node"]["toAddressHash"],
+          from_address: &1["node"]["fromAddressHash"],
+          value: wei_to_eth(&1["node"]["value"]),
+          status: &1["node"]["status"]
+        }
+      )
+
+    %Address{
+      eth_address: eth_address,
+      contract: contract_code,
+      transactions: transactions_struct
+    }
+  end
+
+  defp parse_transactions(_request_result, eth_address) do
+    Logger.warn("Failed ETH transactions for #{eth_address}")
+
+    %Address{
+      eth_address: eth_address,
+      contract: false,
+      transactions: []
+    }
   end
 end

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -1,9 +1,11 @@
 defmodule Address do
+  @moduledoc false
+
   defstruct [:eth_address, :contract, :transactions]
 
   @type t :: %__MODULE__{
-          eth_address: String.t(),
-          contract: boolean(),
-          transactions: list(Transaction.t())
+          eth_address: String.t() | nil,
+          contract: boolean() | nil,
+          transactions: list(Transaction.t()) | nil
         }
 end

--- a/lib/address.ex
+++ b/lib/address.ex
@@ -1,0 +1,9 @@
+defmodule Address do
+  defstruct [:eth_address, :contract, :transactions]
+
+  @type t :: %__MODULE__{
+          eth_address: String.t(),
+          contract: boolean(),
+          transactions: list(Transaction.t())
+        }
+end

--- a/lib/behaviours/api.ex
+++ b/lib/behaviours/api.ex
@@ -1,5 +1,7 @@
 defmodule Behaviours.Api do
+  @moduledoc false
+
   @callback initial_setup() :: :ok
-  @callback transactions_for_address(String.t()) :: any()
-  @callback address_information(String.t()) :: any()
+  @callback transactions_for_address(String.t()) :: Address.t()
+  @callback address_information(String.t()) :: Address.t()
 end

--- a/lib/behaviours/api.ex
+++ b/lib/behaviours/api.ex
@@ -1,0 +1,5 @@
+defmodule Behaviours.Api do
+  @callback initial_setup() :: :ok
+  @callback transactions_for_address(String.t()) :: any()
+  @callback address_information(String.t()) :: any()
+end

--- a/lib/ethcule_poirot/address_explorer.ex
+++ b/lib/ethcule_poirot/address_explorer.ex
@@ -5,6 +5,12 @@ defmodule EthculePoirot.AddressExplorer do
 
   alias EthculePoirot.NetworkExplorer
 
+  @spec start_link(%{
+          eth_address: String.t(),
+          depth: pos_integer(),
+          api_handler: atom()
+        }) ::
+          {:ok, pid()}
   def start_link(%{eth_address: eth_address} = initial_state) do
     {:ok, pid} = GenServer.start_link(__MODULE__, initial_state)
 
@@ -19,10 +25,12 @@ defmodule EthculePoirot.AddressExplorer do
     {:ok, pid}
   end
 
+  @impl true
   def init(initial_state) do
     {:ok, initial_state}
   end
 
+  @impl true
   def handle_info(:start, %{depth: 0} = state) do
     address_information = state.api_handler.address_information(state.eth_address)
     update_node_type(address_information.contract, state.eth_address)
@@ -32,6 +40,7 @@ defmodule EthculePoirot.AddressExplorer do
     {:stop, :normal, state}
   end
 
+  @impl true
   def handle_info(:start, %{depth: depth} = state) do
     state.eth_address
     |> state.api_handler.transactions_for_address()
@@ -42,6 +51,7 @@ defmodule EthculePoirot.AddressExplorer do
     {:stop, :normal, state}
   end
 
+  @spec handle_transactions(Address.t(), pos_integer()) :: any()
   defp handle_transactions(address_information, depth) do
     update_node_type(address_information.contract, address_information.eth_address)
 
@@ -56,9 +66,11 @@ defmodule EthculePoirot.AddressExplorer do
     end)
   end
 
-  defp update_node_type(contract_code, eth_address) when not is_nil(contract_code) do
+  @spec update_node_type(boolean(), String.t()) :: any()
+  defp update_node_type(contract_code, eth_address) when contract_code do
     Neo4j.Client.paint_node(eth_address, "SmartContract")
   end
 
+  @spec update_node_type(nil, String.t()) :: any()
   defp update_node_type(nil, _eth_address), do: :ok
 end

--- a/lib/ethcule_poirot/address_explorer.ex
+++ b/lib/ethcule_poirot/address_explorer.ex
@@ -23,87 +23,42 @@ defmodule EthculePoirot.AddressExplorer do
     {:ok, initial_state}
   end
 
-  def handle_info(:start, state) do
-    explore_address(state.eth_address, state.depth)
+  def handle_info(:start, %{depth: 0} = state) do
+    address_information = state.api_handler.address_information(state.eth_address)
+    update_node_type(address_information.contract, state.eth_address)
+
     NetworkExplorer.visited_node(state.eth_address)
 
     {:stop, :normal, state}
   end
 
-  defp explore_address(eth_address, 0) do
-    Neuron.query(
-      """
-        query($eth_address: AddressHash!) {
-          address(hash: $eth_address) {
-            contractCode
-          }
-        }
-      """,
-      %{eth_address: eth_address}
-    )
-    |> final_node_type(eth_address)
+  def handle_info(:start, %{depth: depth} = state) do
+    state.eth_address
+    |> state.api_handler.transactions_for_address()
+    |> handle_transactions(depth)
+
+    NetworkExplorer.visited_node(state.eth_address)
+
+    {:stop, :normal, state}
   end
 
-  defp explore_address(eth_address, depth) do
-    eth_address
-    |> request_address_transactions()
-    |> process_transactions(eth_address, depth)
-  end
+  defp handle_transactions(address_information, depth) do
+    update_node_type(address_information.contract, address_information.eth_address)
 
-  defp request_address_transactions(eth_address) do
-    Neuron.query(
-      """
-        query($eth_address: AddressHash!) {
-          address(hash: $eth_address) {
-            contractCode
-            transactions(last: 23, count: 23) {
-              edges {
-                node {
-                  hash
-                  toAddressHash
-                  fromAddressHash
-                  value
-                  status
-                }
-              }
-            }
-          }
-        }
-      """,
-      %{eth_address: eth_address}
-    )
-  end
-
-  defp final_node_type({:ok, %Neuron.Response{body: body}}, eth_address) do
-    contract_code = body["data"]["address"]["contractCode"]
-    update_node_type(contract_code, eth_address)
-  end
-
-  defp final_node_type(_request_result, eth_address) do
-    Logger.info("Failed to obtain address type for #{eth_address}")
-    nil
-  end
-
-  defp process_transactions({:ok, %Neuron.Response{body: body}}, eth_address, depth) do
-    transactions = body["data"]["address"]["transactions"]["edges"] || []
-    contract_code = body["data"]["address"]["contractCode"]
-    update_node_type(contract_code, eth_address)
-
-    Enum.each(transactions, fn trx ->
-      next_address = Neo4j.Client.transaction_relation(eth_address, trx)
+    Enum.each(address_information.transactions, fn trx ->
+      next_address =
+        Neo4j.Client.transaction_relation(
+          address_information.eth_address,
+          trx
+        )
 
       NetworkExplorer.visiting_node(next_address, depth - 1)
     end)
-  end
-
-  defp process_transactions(_request_result, eth_address, _depth) do
-    Logger.info("Failed ETH transactions for #{eth_address}")
-    nil
   end
 
   defp update_node_type(contract_code, eth_address) when not is_nil(contract_code) do
     Neo4j.Client.paint_node(eth_address, "SmartContract")
   end
 
-  defp update_node_type(nil, _eth_address), do: nil
+  defp update_node_type(nil, _eth_address), do: :ok
 end

--- a/lib/ethcule_poirot/application.ex
+++ b/lib/ethcule_poirot/application.ex
@@ -12,14 +12,6 @@ defmodule EthculePoirot.Application do
       {EthculePoirot.DynamicSupervisor, []}
     ]
 
-    Neuron.Config.set(url: Application.fetch_env!(:ethcule_poirot, :api_url))
-
-    Neuron.Config.set(
-      connection_opts: [
-        recv_timeout: Application.fetch_env!(:ethcule_poirot, :api_timeout)
-      ]
-    )
-
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: EthculePoirot.Supervisor]

--- a/lib/ethcule_poirot/dynamic_supervisor.ex
+++ b/lib/ethcule_poirot/dynamic_supervisor.ex
@@ -5,12 +5,14 @@ defmodule EthculePoirot.DynamicSupervisor do
 
   alias EthculePoirot.{AddressExplorer, NetworkExplorer}
 
+  @spec start_link(list()) :: any()
   def start_link(init_arg) do
     DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
 
     DynamicSupervisor.start_child(__MODULE__, {NetworkExplorer, %{}})
   end
 
+  @spec start_address_explorer(String.t(), pos_integer(), atom()) :: any()
   def start_address_explorer(eth_address, depth, api_handler) do
     spec =
       {AddressExplorer,

--- a/lib/ethcule_poirot/dynamic_supervisor.ex
+++ b/lib/ethcule_poirot/dynamic_supervisor.ex
@@ -11,8 +11,15 @@ defmodule EthculePoirot.DynamicSupervisor do
     DynamicSupervisor.start_child(__MODULE__, {NetworkExplorer, %{}})
   end
 
-  def start_address_explorer(eth_address, depth) do
-    spec = {AddressExplorer, %{eth_address: eth_address, depth: depth}}
+  def start_address_explorer(eth_address, depth, api_handler) do
+    spec =
+      {AddressExplorer,
+       %{
+         eth_address: eth_address,
+         depth: depth,
+         api_handler: api_handler
+       }}
+
     DynamicSupervisor.start_child(__MODULE__, spec)
   end
 

--- a/lib/ethcule_poirot/network_explorer.ex
+++ b/lib/ethcule_poirot/network_explorer.ex
@@ -7,18 +7,22 @@ defmodule EthculePoirot.NetworkExplorer do
 
   @default_api_adapter Application.compile_env(:ethcule_poirot, :default_api_adapter)
 
+  @spec explore(String.t(), pos_integer(), atom() | any()) :: any()
   def explore(eth_address, depth, api_adapter \\ @default_api_adapter) do
     send(__MODULE__, {:start, eth_address, depth, api_adapter})
   end
 
+  @spec start_link(map()) :: any()
   def start_link(initial_state) do
     GenServer.start_link(__MODULE__, initial_state, name: __MODULE__)
   end
 
+  @impl true
   def init(state) do
     {:ok, state}
   end
 
+  @impl true
   def handle_info({:start, eth_address, depth, api_adapter}, state) do
     downcased_address = String.downcase(eth_address)
     api_adapter.initial_setup()
@@ -36,6 +40,7 @@ defmodule EthculePoirot.NetworkExplorer do
     {:noreply, Map.merge(state, new_state)}
   end
 
+  @impl true
   def handle_info({:visiting, eth_address, depth}, state) do
     if MapSet.member?(state.visited, eth_address) do
       Logger.info("Already explored #{eth_address}")
@@ -50,6 +55,7 @@ defmodule EthculePoirot.NetworkExplorer do
     end
   end
 
+  @impl true
   def handle_info({:visited, eth_address}, state) do
     new_remaining = MapSet.delete(state.remaining, eth_address)
 
@@ -62,10 +68,12 @@ defmodule EthculePoirot.NetworkExplorer do
     {:noreply, Map.merge(state, %{remaining: new_remaining})}
   end
 
+  @spec visiting_node(String.t(), pos_integer()) :: any()
   def visiting_node(eth_address, depth) do
     send(__MODULE__, {:visiting, eth_address, depth})
   end
 
+  @spec visited_node(String.t()) :: any()
   def visited_node(eth_address) do
     send(__MODULE__, {:visited, eth_address})
   end

--- a/lib/ethcule_poirot/network_explorer.ex
+++ b/lib/ethcule_poirot/network_explorer.ex
@@ -40,6 +40,8 @@ defmodule EthculePoirot.NetworkExplorer do
       new_visited = MapSet.put(state.visited, eth_address)
       new_remaining = MapSet.put(state.remaining, eth_address)
 
+      # api_impl = passed value or default from config
+
       DynamicSupervisor.start_address_explorer(eth_address, depth)
 
       {:noreply, Map.merge(state, %{visited: new_visited, remaining: new_remaining})}

--- a/lib/neo4j/chyper.ex
+++ b/lib/neo4j/chyper.ex
@@ -1,6 +1,7 @@
 defmodule Neo4j.Cypher do
   @moduledoc false
 
+  @spec prepared_statement(String.t(), keyword({atom(), String.t()})) :: String.t()
   def prepared_statement(query_string, variables \\ []) when is_list(variables) do
     prepared_vars =
       Enum.map(variables, fn {key, value} ->

--- a/lib/neo4j/client.ex
+++ b/lib/neo4j/client.ex
@@ -5,15 +5,18 @@ defmodule Neo4j.Client do
   alias Bolt.Sips, as: Neo
   alias Neo4j.Cypher
 
+  @spec start_link(any()) :: any()
   def start_link(_initial_state) do
     initial_state = %{conn: Neo.conn()}
     GenServer.start_link(__MODULE__, initial_state, name: __MODULE__)
   end
 
+  @impl true
   def init(initial_state) do
     {:ok, initial_state}
   end
 
+  @impl true
   def handle_info(:clear_database, state) do
     cypher = "MATCH (a)-[r]->(b) DELETE a, r, b"
 
@@ -22,6 +25,7 @@ defmodule Neo4j.Client do
     {:noreply, state}
   end
 
+  @impl true
   def handle_info(:create_indexes, state) do
     index_nodes = "CREATE INDEX EthAddressIndex IF NOT EXISTS FOR (a:Account) ON (a.eth_address)"
 
@@ -33,6 +37,7 @@ defmodule Neo4j.Client do
     {:noreply, state}
   end
 
+  @impl true
   def handle_info({:paint_node, eth_address, new_label_string}, state) do
     downcased_address = String.downcase(eth_address)
 
@@ -49,6 +54,7 @@ defmodule Neo4j.Client do
     {:noreply, state}
   end
 
+  @impl true
   def handle_info({:highlight_accounts_of_interest, addresses}, state) do
     addresses
     |> Enum.each(&paint_node(String.downcase(&1), "Interest"))
@@ -56,6 +62,7 @@ defmodule Neo4j.Client do
     {:noreply, state}
   end
 
+  @impl true
   def handle_call({:transaction_relation, eth_address, transaction}, _from, state) do
     to_address = transaction.to_address
     from_address = transaction.from_address
@@ -89,22 +96,27 @@ defmodule Neo4j.Client do
     {:reply, next_address, state}
   end
 
+  @spec clear_database() :: any()
   def clear_database do
     send(__MODULE__, :clear_database)
   end
 
+  @spec create_indexes() :: any()
   def create_indexes do
     send(__MODULE__, :create_indexes)
   end
 
+  @spec paint_node(String.t(), String.t()) :: any()
   def paint_node(eth_address, new_label_string) do
     send(__MODULE__, {:paint_node, eth_address, new_label_string})
   end
 
+  @spec highlight_accounts_of_interest(String.t()) :: any()
   def highlight_accounts_of_interest(addresses) do
     send(__MODULE__, {:highlight_accounts_of_interest, addresses})
   end
 
+  @spec transaction_relation(String.t(), String.t()) :: String.t()
   def transaction_relation(eth_address, transaction) do
     GenServer.call(__MODULE__, {:transaction_relation, eth_address, transaction}, :infinity)
   end

--- a/lib/neo4j/supervisor.ex
+++ b/lib/neo4j/supervisor.ex
@@ -3,6 +3,7 @@ defmodule Neo4j.Supervisor do
 
   use Supervisor
 
+  @spec start_link(any()) :: any()
   def start_link(opts) do
     Supervisor.start_link(__MODULE__, :ok, opts)
   end

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -1,0 +1,12 @@
+defmodule Transaction do
+  @enforce_keys [:hash, :to_address, :from_address, :value, :status]
+  defstruct [:hash, :to_address, :from_address, :value, :status]
+
+  @type t :: %__MODULE__{
+          hash: String.t(),
+          to_address: String.t(),
+          from_address: String.t(),
+          value: String.t(),
+          status: String.t()
+        }
+end

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -1,4 +1,6 @@
 defmodule Transaction do
+  @moduledoc false
+
   @enforce_keys [:hash, :to_address, :from_address, :value, :status]
   defstruct [:hash, :to_address, :from_address, :value, :status]
 

--- a/test/ethcule_poirot/dynamic_supervisor_test.exs
+++ b/test/ethcule_poirot/dynamic_supervisor_test.exs
@@ -13,7 +13,8 @@ defmodule EthculePoirot.DynamicSupervisorTest do
 
   describe "start_address_explorer/2" do
     test "adds an address explorer GenServer to the dynamic sup" do
-      assert {:ok, _pid} = DynamicSupervisor.start_address_explorer("0x123", 2)
+      api_adapter = Adapters.Api.Blockscout
+      assert {:ok, _pid} = DynamicSupervisor.start_address_explorer("0x123", 2, api_adapter)
     end
   end
 end


### PR DESCRIPTION
Why:
 - Defining a behaviour that API adapters should implement. This way we can use more than one different API (other than Blockscout's), or an Ethereum node if the behaviour is implemented.
 
How:
 - Created a behaviour with a set of functions to explore an address
 - Implemented that behaviour for the Blockscout API and used it as default, if no Adapter is specified.
 - Defined config vars for the new Adapter Module.
 - Added spec types for function definitions.