### PR TITLE
Control the number of Processes running at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,5 @@ Neo4j.Client.clear_database
 
 - [ ] Add Tests using [Mox](https://hexdocs.pm/mox/Mox.html) to interact with the Blockscout API and Neo4j.
 - [ ] Create an Adapter for `Neo4J.Client`. This way the project can become agnostic on the underlying database provided that the new adapter specifies the Graph structure to be used. With it, we could explore SmartContracts in particular, and just use the project as tooling.
-- [ ] Request more transactions per wallet, using the GraphQL cursors provided by Blockscout API.
-- [ ] Differentiate `Pending`, `ERROR`, and `OK` transactions. Maybe different relationships. (For now, a solution is to use "conditional styling" for relationships in `Neo4J Bloom`.)
+- [ ] Request more transactions per wallet, using the GraphQL cursors provided by Blockscout API, or using a different API.
 - [ ] Explore through internal transactions, also.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By using Neo4J we're also able to use their built in services like [Bloom](https
 Looking at the image below, there's a clear structure for the supervision tree of this project. On one side we have Processes related to the Database interaction, and on the other we have processes that take care of the exploration of each address.
 
 - `Neo4j.Client`: is a GenServer that holds the `conn` in the state and exposes the respective API to exexute queries in the DB.
-- `EthculePoirot.NetworkExplorer`: is a GenServer that holds the Set of visited nodes, the ones that are being explored by `EthculePoirot.AddressExplorer` and other info required to manage the exploration step.
+- `EthculePoirot.NetworkExplorer`: is a GenServer that holds the Set of visited nodes, the ones that are being explored by `EthculePoirot.AddressExplorer` and other info required to manage the exploration step. It also manages the number of Addresses being explored at the same time, through a `pool_size` configuration.
 
 ![supervision tree](images/supervision-tree.png)
 
@@ -31,7 +31,7 @@ Looking at the image below, there's a clear structure for the supervision tree o
 It's possible to use different APIs to index and build the desired network. For example, we can use an API that provides the Blockchain transaction history to map interactions between addresses, but we can also use an API like a [Subgraph](https://thegraph.com/hosted-service/) and build a network of interactions between an Address and one/several SmartContract(s).
 
 ### Existing
- - [Blockscout](https://blockscout.com/eth/mainnet/graphiql): It's free to use and it already gives us transactions and addresses already organized with a lot of information that we need to build our own network. 
+ - [Blockscout](https://blockscout.com/eth/mainnet/graphiql): It's free to use and it returns transactions and addresses already organized with a lot of information that we need to build our own network. 
    The downside of using it is rate limits from Cloudflare, and a low complexity GraphQL query, that only enables us to query 22 transactions at a time (with the current information we are requesting).
  - [Dissrup TheGraph NFT sales](https://thegraph.com/hosted-service/subgraph/dissrup-admin/mainnet-v12): Dissrup is a NFT marketplace, and using TheGraph's API it's possible to inspect NFT Sales. This is a proof of concept that the project doesn't need to explore only Ethereum transactions.
 
@@ -77,7 +77,7 @@ bin/server
 
 This will start the application and the respective Supervisors for the Explorers and Neo4j interactions.
 
-After the app starts, to start exploring just pass in an address, and an exploration depth to ` EthculePoirot.NetworkExplorer.explore/2`. It's advised to use a depth of 3, due to API requests failing for higher values. (Take into account that the number of requests made increases exponentially with `depth`.)
+After the app starts, to start exploring just pass in an address, and an exploration depth to ` EthculePoirot.NetworkExplorer.explore/2`. (It's advised to use a depth of 3)
 
 ```elixir
 # using the Blockscout API as default
@@ -103,11 +103,8 @@ Neo4j.Client.clear_database
 
 ## Future Development Ideas
 
-- [X] Create an Adapter for the `AddressExplorer` to work with different APIs and/or an Ethereum Node.
-- [X] Add support for ENS for highlighting accounts of interest.
 - [ ] Add Tests using [Mox](https://hexdocs.pm/mox/Mox.html) to interact with the Blockscout API and Neo4j.
 - [ ] Create an Adapter for `Neo4J.Client`. This way the project can become agnostic on the underlying database provided that the new adapter specifies the Graph structure to be used. With it, we could explore SmartContracts in particular, and just use the project as tooling.
 - [ ] Request more transactions per wallet, using the GraphQL cursors provided by Blockscout API.
-- [ ] Create a scheduler to pick from the `remaining` pool of addresses and set a concurrency number. [Poolboy](https://elixirschool.com/en/lessons/misc/poolboy) for reference.
 - [ ] Differentiate `Pending`, `ERROR`, and `OK` transactions. Maybe different relationships. (For now, a solution is to use "conditional styling" for relationships in `Neo4J Bloom`.)
 - [ ] Explore through internal transactions, also.

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,8 @@ config :bolt_sips, Bolt,
   pool_size: 200
 
 config :ethcule_poirot,
-  default_api_adapter: Adapters.Api.Blockscout
+  default_api_adapter: Adapters.Api.Blockscout,
+  pool_size: 10
 
 config :ethcule_poirot, Adapters.Api.Blockscout,
   api_url: System.get_env("BLOCKSCOUT_API_URL"),

--- a/lib/ethcule_poirot/network_explorer.ex
+++ b/lib/ethcule_poirot/network_explorer.ex
@@ -6,6 +6,7 @@ defmodule EthculePoirot.NetworkExplorer do
   alias EthculePoirot.DynamicSupervisor
 
   @default_api_adapter Application.compile_env(:ethcule_poirot, :default_api_adapter)
+  @pool_size Application.get_env(:ethcule_poirot, :pool_size)
 
   @spec explore(String.t(), pos_integer(), atom() | any()) :: any()
   def explore(eth_address, depth, api_adapter \\ @default_api_adapter) do
@@ -30,51 +31,105 @@ defmodule EthculePoirot.NetworkExplorer do
     new_state = %{
       eth_address: downcased_address,
       depth: depth,
-      visited: MapSet.new(),
-      remaining: MapSet.new(),
-      api_adapter: api_adapter
+      known: MapSet.new(),
+      exploring: MapSet.new(),
+      remaining: [],
+      api_adapter: api_adapter,
+      processes_count: 0
     }
 
-    send(__MODULE__, {:visiting, downcased_address, depth})
+    send(__MODULE__, {:add_to_queue, downcased_address, depth})
 
     {:noreply, Map.merge(state, new_state)}
   end
 
   @impl true
-  def handle_info({:visiting, eth_address, depth}, state) do
-    if MapSet.member?(state.visited, eth_address) do
+  def handle_info({:add_to_queue, eth_address, depth}, state) do
+    if MapSet.member?(state.known, eth_address) do
       Logger.info("Already explored #{eth_address}")
       {:noreply, state}
     else
-      new_visited = MapSet.put(state.visited, eth_address)
-      new_remaining = MapSet.put(state.remaining, eth_address)
+      new_known = MapSet.put(state.known, eth_address)
 
-      DynamicSupervisor.start_address_explorer(eth_address, depth, state.api_adapter)
+      {processes_count, new_remaining, new_exploring} =
+        add_to_queue(
+          eth_address,
+          depth,
+          state
+        )
 
-      {:noreply, Map.merge(state, %{visited: new_visited, remaining: new_remaining})}
+      {:noreply,
+       Map.merge(state, %{
+         known: new_known,
+         exploring: new_exploring,
+         remaining: new_remaining,
+         processes_count: processes_count
+       })}
     end
   end
 
   @impl true
-  def handle_info({:visited, eth_address}, state) do
-    new_remaining = MapSet.delete(state.remaining, eth_address)
+  def handle_info({:remove_from_queue, eth_address}, state) do
+    new_exploring = MapSet.delete(state.exploring, eth_address)
+    exploring_size = MapSet.size(new_exploring)
+    remaining_size = length(state.remaining)
 
-    if MapSet.size(new_remaining) == 0 do
-      Neo4j.Client.paint_node(state.eth_address, "Initial")
+    {processes_count, new_remaining} =
+      remove_from_queue(
+        exploring_size,
+        remaining_size,
+        state
+      )
 
-      Logger.info("Fully explored #{state.eth_address}")
-    end
-
-    {:noreply, Map.merge(state, %{remaining: new_remaining})}
+    {:noreply,
+     Map.merge(state, %{
+       remaining: new_remaining,
+       exploring: new_exploring,
+       processes_count: processes_count
+     })}
   end
 
-  @spec visiting_node(String.t(), pos_integer()) :: any()
-  def visiting_node(eth_address, depth) do
-    send(__MODULE__, {:visiting, eth_address, depth})
+  @spec visit_node(String.t(), pos_integer()) :: any()
+  def visit_node(eth_address, depth) do
+    send(__MODULE__, {:add_to_queue, eth_address, depth})
   end
 
-  @spec visited_node(String.t()) :: any()
-  def visited_node(eth_address) do
-    send(__MODULE__, {:visited, eth_address})
+  @spec node_visited(String.t()) :: any()
+  def node_visited(eth_address) do
+    send(__MODULE__, {:remove_from_queue, eth_address})
+  end
+
+  @spec add_to_queue(String.t(), pos_integer(), map()) :: {pos_integer(), list(), MapSet.t()}
+  defp add_to_queue(eth_address, depth, %{processes_count: processes} = state)
+       when processes < @pool_size do
+    DynamicSupervisor.start_address_explorer(eth_address, depth, state.api_adapter)
+
+    new_exploring = MapSet.put(state.exploring, eth_address)
+    {state.processes_count + 1, state.remaining, new_exploring}
+  end
+
+  defp add_to_queue(eth_address, depth, state) do
+    new_remaining = [{eth_address, depth} | state.remaining]
+
+    {state.processes_count, new_remaining, state.exploring}
+  end
+
+  @spec remove_from_queue(pos_integer(), pos_integer(), map()) :: {pos_integer(), list()}
+  defp remove_from_queue(0, 0, state) do
+    Neo4j.Client.paint_node(state.eth_address, "Initial")
+
+    Logger.info("Fully explored #{state.eth_address}")
+    {0, state.remaining}
+  end
+
+  defp remove_from_queue(_exploring_size, remaining_size, state) when remaining_size > 0 do
+    {{next_address, next_depth}, new_remaining} = List.pop_at(state.remaining, 0)
+
+    DynamicSupervisor.start_address_explorer(next_address, next_depth, state.api_adapter)
+    {state.processes_count, new_remaining}
+  end
+
+  defp remove_from_queue(_exploring_size, _remaining_size, state) do
+    {state.processes_count - 1, state.remaining}
   end
 end

--- a/lib/ethcule_poirot/network_explorer.ex
+++ b/lib/ethcule_poirot/network_explorer.ex
@@ -6,7 +6,7 @@ defmodule EthculePoirot.NetworkExplorer do
   alias EthculePoirot.DynamicSupervisor
 
   @default_api_adapter Application.compile_env(:ethcule_poirot, :default_api_adapter)
-  @pool_size Application.get_env(:ethcule_poirot, :pool_size)
+  @pool_size Application.compile_env(:ethcule_poirot, :pool_size)
 
   @spec explore(String.t(), pos_integer(), atom() | any()) :: any()
   def explore(eth_address, depth, api_adapter \\ @default_api_adapter) do


### PR DESCRIPTION
Why:
 - To have more control over the number of concurrent processes running at the same time, exploring different addresses (making requests to the API).
 - Define a maximum number of running processes, and queue to manage everything.

How:
 - Renaming some variables in the state for a better understanding of what they refer to, like `visited` vs `known` nodes.
 - Added a queue that's managed by the `NetworkExplorer`, and ensures that only the maximum of `pool_size` processes is running at the same time.
 - Pick from the remaining queue, when an `AddressExplorer` finishes its job.