### PR TITLE
Fix local Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ end
 bin/setup
 
 # or to setup everything inside Docker
+# to use Neo4j with Docker, comment out `:ssl` option in the `config/config.exs` file
 bin/setup_docker
 ``` 
 

--- a/bin/server_docker
+++ b/bin/server_docker
@@ -5,4 +5,4 @@ docker-compose up -d
 sleep 5
 
 echo "Ready? Try 'EthculePoirot.NetworkExplorer.explore(ADDRESS, DEPTH)'"
-docker attach $(docker ps -a | grep ethcule-poirot-ethcule | awk '{ print $1 }')
+docker attach $(docker ps -a | grep ethcule-poirot_ethcule | awk '{ print $1 }')

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,7 @@ import Config
 
 config :bolt_sips, Bolt,
   url: System.get_env("DATABASE_URL"),
+  # Comment out ssl if using local connection
   ssl: [verify: :verify_none],
   basic_auth: [username: System.get_env("NEO4J_USER"), password: System.get_env("NEO4J_PASSWORD")],
   pool_size: 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   core1:
     container_name: core1
-    image: neo4j:latest
+    image: neo4j:4.3.22
     networks:
       - lan
     ports:


### PR DESCRIPTION
Why:
 - As per Issue #3 , When using the docker `server` script, the correct Docker ID was not being matched.
 - The docker-compose file was using `latest` image from Neo4j. Hardcoding to `4.3.22`, for now, just to avoid breaking the setup with newer versions.

How:
 - Updating `bin/server_docker` to match the correct container name.
 - Updating Neo4j version in `docker-compose.yml`
 - Adding a comment to README and config that for local connections it's necessary to comment out the `:ssl` option.